### PR TITLE
Update README for auto deploy section clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@
 - [X] `► Configure DNS`
 - [X] `► Add https`
 - [ ] `► Add this project on the website`
-- [X] `► Add auto deploy with auto release with semantic (no ci)`
+- [X] `► Add auto deploy with auto release with semantic`
 - [ ] `► New design ?`
 
 ---


### PR DESCRIPTION
Remove the 'no ci' indication from the auto deploy section in the README to enhance clarity.