### PR TITLE
Update README to remove 'TEST' from auto deploy section

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@
 - [X] `► Configure DNS`
 - [X] `► Add https`
 - [ ] `► Add this project on the website`
-- [X] `► Add auto deploy with auto release with semantic TEST`
+- [X] `► Add auto deploy with auto release with semantic`
 - [ ] `► New design ?`
 
 ---


### PR DESCRIPTION
Clarify the auto deploy section in the README by removing the 'TEST' reference.